### PR TITLE
Update/gpu-shell-command

### DIFF
--- a/docs/src/usage/run-workload-examples.md
+++ b/docs/src/usage/run-workload-examples.md
@@ -136,6 +136,7 @@ Use this example to spawn an ephemeral shell with access to GPU resources.
 <div class="warning">
 
 The example GPU shell will **auto terminate after 25 minutes, DO NOT** use for consistent workloads.
+</div>
 
 ```yaml
 # gpu-shell.yaml


### PR DESCRIPTION
Update yaml file for GPU shell command to prevent users from forgetting to terminate the pod.
Pod lifetime is set to 25minutes.

`sleep inf`  -> `'sleep 1500 && echo "Time expired. Exiting..." && exit'`