### PR TITLE
feat: include busybox in the layered image contents

### DIFF
--- a/image.nix
+++ b/image.nix
@@ -4,12 +4,13 @@
   sgs,
   cacert,
   tini,
+  busybox,
 }:
 
 dockerTools.buildLayeredImage {
   inherit (sgs) name;
 
-  contents = [ cacert ];
+  contents = [ cacert busybox ];
   config = {
     Entrypoint = [
       (lib.getExe tini)


### PR DESCRIPTION
This pull request makes a small update to the `image.nix` file by adding `busybox` to the Docker image contents. This will provide additional basic Unix utilities in the resulting image.